### PR TITLE
Fix link to examples directory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A helper to make creating unix daemons easier.
 
-See the [docs](https://docs.rs/spirit) and the [examples](../../tree/master/examples).
+See the [docs](https://docs.rs/spirit) and the [examples](https://github.com/vorner/spirit/tree/master/examples).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A helper to make creating unix daemons easier.
 
-See the [docs](https://docs.rs/spirit) and the [examples](tree/master/examples).
+See the [docs](https://docs.rs/spirit) and the [examples](../../tree/master/examples).
 
 ## License
 


### PR DESCRIPTION
the link was taking me to https://github.com/vorner/spirit/blob/master/tree/master/examples when clicked from the github readme

(sorry about the two commits, I was doing it through github's web interface)