### PR TITLE
Set up the guide on github pages

### DIFF
--- a/.github/workflows/user_guide.yaml
+++ b/.github/workflows/user_guide.yaml
@@ -1,0 +1,52 @@
+name: User guide
+
+on:
+  # We run on each push, to verify the guide can be built, but publish only once in master.
+  # TODO: We also want to do so for tags and publish into some kind of
+  # subdirectory. But for that we probably want to keep the history?
+  # https://github.com/peaceiris/actions-gh-pages/issues/324 to the rescue?
+  - push
+
+jobs:
+  mdbook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+
+      - name: Restore cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: latest
+
+      - name: Build docs
+        run: cargo doc --all --all-features
+
+      - name: Build the book
+        run: mdbook build user-guide
+
+      - name: Compose publish dirs
+        run: |
+          mkdir publish
+          cp -r target/doc publish/doc
+          cp -r target/user-guide publish/user-guide
+          echo '<head><meta http-equiv="refresh" content="0; URL=user-guide/index.html"/></head>' > publish/index.html
+
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501
+        if: github.ref == 'refs/heads/master'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./publish
+          force_orphan: true
+


### PR DESCRIPTION
Not sure if we want to have it as the github pages (maybe we can still
somehow make subdirectories with versions and keep them?