### PR TITLE
Utils & guide for mock application testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# spirit-0.4.19
+
+* `App::run_test` for easier management of spirit mock "applications" inside
+  tests.
+* Added guide for the above testing.
+
 # spirit-0.4.18
 
 * Fix panic in `on_terminate` called after terminating.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "spirit"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "arc-swap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirit"
-version = "0.4.18"
+version = "0.4.19"
 authors = ["Michal 'vorner' Vaner <vorner@vorner.cz>"]
 description = "Helper to create well behaved daemons with runtime-reconfiguration support"
 documentation = "https://docs.rs/spirit"

--- a/src/cfg_loader.rs
+++ b/src/cfg_loader.rs
@@ -41,6 +41,13 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # Testing support
+//!
+//! Oftentimes, the need to have a custom config loader stems from testing. See the [testing guide]
+//! for details.
+//!
+//! testing guide: crate::guide::testing
 
 use std::collections::{HashMap, HashSet};
 use std::error::Error;

--- a/src/guide/mod.rs
+++ b/src/guide/mod.rs
@@ -36,6 +36,7 @@ You'll find here:
   - [Using fragments and pipelines][self::fragments]
   - [Extending with own fragments][self::extend]
   - [Proper daemonization and early startup][self::daemonization]
+  - [Testing][self::testing]
 */
 
 pub mod configuration;
@@ -44,4 +45,5 @@ pub mod extend;
 pub mod fragments;
 pub mod levels;
 pub mod principles;
+pub mod testing;
 pub mod tutorial;

--- a/src/guide/testing.rs
+++ b/src/guide/testing.rs
@@ -1,0 +1,86 @@
+/*!
+Testing
+
+Sometimes, during tests, one might want to run an almost-full application. It can be done by
+executing the compiled binary externally, but such thing is quite heavy-weight to orchestrate
+(making sure it is already compiled, providing configuration, waiting for it to become ready,
+shutting it down properly).
+
+Alternatively, it is possible to get close to full application setup inside a local test function
+with spirit.
+
+First, make sure the application setup is a separate function that can be applied to the spirit
+[Builder]. That'll allow the tests [Spirit] to use the same core setup as the application. The only
+missing part is passing the right configuration and arguments to it (because it should *not* use
+the arguments passed to the test process). To do so, the [config Builder] can be used.
+
+We also disable the background management thread. First, we want to make sure we don't touch signal
+handlers so things work as expected. Second, this allows having multiple parallel instances of the
+"application" (rust tests run in parallel).
+
+[Builder]: crate::Builder
+[Spirit]: crate::Spirit
+[config Builder]: crate::cfg_loader::Builder
+
+```rust
+// This goes to some tests/something.rs or similar place.
+use std::sync::{mpsc, Arc};
+
+use spirit::cfg_loader::Builder as CfgBuilder;
+use spirit::prelude::*;
+use spirit::{Empty, Spirit};
+
+// Custom configuration "file"
+let TEST_CFG: &str = r#"
+[section]
+option = true
+"#;
+
+let cfg_loader = CfgBuilder::new()
+    .config_defaults(TEST_CFG);
+
+// Note: Some "real" config and opts structures are likely used here.
+let app = Spirit::<Empty, Empty>::new()
+    // Inject the config loader with the "config file" in it.
+    .config_loader(cfg_loader)
+    // Provide already parsed command line argument structure here. Ours is `Empty` here, but it's
+    // whatever you use in the app.
+    //
+    // This also ignores the real command line arguments, so it's important to call in the test
+    // even if you pass `Default::default()`. We want to ignore the arguments passed to the test
+    // binary.
+    .preparsed_opts(Empty::default())
+    // False -> we don't have the background management thread that listens to signals. Lifetime is
+    // managed in a different way here in the test.
+    .build(false)
+    .expect("Failed to create the test spirit app");
+
+// We want to wait for the background thread to fully start up as necessary so the test doesn't do
+// its stuff too early. We'll let the application to signal us.
+let (ready_send, ready_recv) = mpsc::channel::<()>();
+
+// A spirit copy to go inside the closure below.
+let spirit = Arc::clone(app.spirit());
+
+// The running is a RAII guard. Once it's dropped, it will terminate spirit and check it terminated
+// correctly. Runs the application in another thread.
+let running = app.run_test(move || {
+    // Once everything is started up enough for the test to start doing stuff, we'll tell it to
+    // proceed (ignore errors in case the test somehow died).
+    let _ = ready_send.send(());
+    // The inside of the application. You should have a function that goes inside `run` and
+    // call it both here and from the real `main`'s `run`.
+    while !spirit.is_terminated() {
+        // Do stuff!
+    }
+    Ok(())
+});
+
+// Wait for the background thread to be ready (or dead, which would error out and the test would
+// fail).
+let _ = ready_recv.recv();
+
+// Now, we can do our testing here. After we are done, the above will just shut down all the stuff.
+assert!(!running.spirit().is_terminated());
+```
+*/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod guide;
 #[doc(hidden)]
 pub mod macro_support;
 mod spirit;
+pub mod terminate_guard;
 pub mod utils;
 pub mod validation;
 

--- a/src/terminate_guard.rs
+++ b/src/terminate_guard.rs
@@ -1,0 +1,75 @@
+//! A termination RAII guard for test purposes.
+//!
+//! See the [testing guide] for details.
+//!
+//! testing guide: crate::guide::testing
+
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+use serde::de::DeserializeOwned;
+use structopt::StructOpt;
+
+use crate::{AnyError, Spirit};
+
+/// The termination RAII guard for test purposes.
+///
+/// See the [testing guide] for details of use. Created by
+/// [App::run_test][run_test].
+///
+/// Note that this will shut down (call `terminate`) when dropped and wait for the termination to
+/// happen. It'll then check that everything went successfully and panic if not. This is meant for
+/// tests, so it's desired behaviour.
+///
+/// # Panics
+///
+/// The **destructor** may panic if the contained spirit app fails during termination. See above.
+///
+/// [testing guide]: crate::guide::testing
+/// [run_test]: crate::app::App::run_test
+pub struct TerminateGuard<O, C>
+where
+    C: DeserializeOwned + Send + Sync,
+    O: StructOpt,
+{
+    spirit: Arc<Spirit<O, C>>,
+    bg: Option<JoinHandle<Result<(), AnyError>>>,
+}
+
+impl<O, C> TerminateGuard<O, C>
+where
+    C: DeserializeOwned + Send + Sync,
+    O: StructOpt,
+{
+    pub(crate) fn new(spirit: Arc<Spirit<O, C>>, bg: JoinHandle<Result<(), AnyError>>) -> Self {
+        Self {
+            spirit,
+            bg: Some(bg),
+        }
+    }
+
+    /// Access to the managed [Spirit] instance.
+    pub fn spirit(&self) -> &Arc<Spirit<O, C>> {
+        &self.spirit
+    }
+}
+
+impl<O, C> Drop for TerminateGuard<O, C>
+where
+    C: DeserializeOwned + Send + Sync,
+    O: StructOpt,
+{
+    fn drop(&mut self) {
+        self.spirit.terminate();
+        let result = self
+            .bg
+            .take()
+            .expect("Drop called multiple times?!? Missing the join handle")
+            .join();
+        if !thread::panicking() {
+            result
+                .expect("Spirit test thread panicked")
+                .expect("Test spirit terminated with an error");
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,6 +44,7 @@ use crate::AnyError;
 ///
 /// use structopt::StructOpt;
 ///
+/// # #[allow(dead_code)]
 /// #[derive(Debug, StructOpt)]
 /// struct MyOpts {
 ///     #[structopt(short = "p", parse(from_os_str = spirit::utils::absolute_from_os_str))]
@@ -89,6 +90,7 @@ impl Error for MissingEquals {}
 ///
 /// ```rust
 /// # use structopt::StructOpt;
+/// # #[allow(dead_code)]
 /// #[derive(Debug, StructOpt)]
 /// struct MyOpts {
 ///     #[structopt(
@@ -127,6 +129,7 @@ where
 ///
 /// use spirit::utils::Hidden;
 ///
+/// # #[allow(dead_code)]
 /// #[derive(Debug)]
 /// struct Cfg {
 ///     username: String,


### PR DESCRIPTION
Mostly running almost the full application inside a test (as an
alternative to compile the binary and execute it externally, which is
problematic).